### PR TITLE
スラブ情報比較部分の例外

### DIFF
--- a/STB-DiffChecker/Record/v201/Slabs.cs
+++ b/STB-DiffChecker/Record/v201/Slabs.cs
@@ -175,7 +175,7 @@ namespace STBDiffChecker.v201.Records
                                 {
                                     StbSlabStbOpenIdList.Compare(nameof(StbOpenIdList), null, key, records);
                                 }
-                                else if (b.StbNodeIdOrder == null)
+                                else if (a.StbOpenIdList == null)
                                 {
                                     StbSlabStbOpenIdList.Compare(null, nameof(StbOpenIdList), key, records);
                                 }


### PR DESCRIPTION
モデルの比較を行った際に、モデルAの開口IDリストがnullの際に例外が発生しました。
if分の条件式がb.StbNodeIdOrderではなく、a.StbOpenIdListではないでしょうか？
ご確認よろしくお願いします。